### PR TITLE
Civix upgrade to address PHP warnings

### DIFF
--- a/capscorrect.civix.php
+++ b/capscorrect.civix.php
@@ -3,104 +3,198 @@
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
 
 /**
- * (Delegated) Implementation of hook_civicrm_config
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_Capscorrect_ExtensionUtil {
+  const SHORT_NAME = 'capscorrect';
+  const LONG_NAME = 'uk.org.futurefirst.networks.capscorrect';
+  const CLASS_PREFIX = 'CRM_Capscorrect';
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = []) {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = [self::LONG_NAME, NULL];
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL) {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_Capscorrect_ExtensionUtil as E;
+
+function _capscorrect_civix_mixin_polyfill() {
+  if (!class_exists('CRM_Extension_MixInfo')) {
+    $polyfill = __DIR__ . '/mixin/polyfill.php';
+    (require $polyfill)(E::LONG_NAME, E::SHORT_NAME, E::path());
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_config().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
 function _capscorrect_civix_civicrm_config(&$config = NULL) {
   static $configured = FALSE;
-  if ($configured) return;
+  if ($configured) {
+    return;
+  }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname( __FILE__ ) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
-  if ( is_array( $template->template_dir ) ) {
-      array_unshift( $template->template_dir, $extDir );
-  } else {
-      $template->template_dir = array( $extDir, $template->template_dir );
+  if (is_array($template->template_dir)) {
+    array_unshift($template->template_dir, $extDir);
+  }
+  else {
+    $template->template_dir = [$extDir, $template->template_dir];
   }
 
-  $include_path = $extRoot . PATH_SEPARATOR . get_include_path( );
-  set_include_path( $include_path );
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+  set_include_path($include_path);
+  _capscorrect_civix_mixin_polyfill();
 }
 
 /**
- * (Delegated) Implementation of hook_civicrm_xmlMenu
+ * Implements hook_civicrm_install().
  *
- * @param $files array(string)
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
- */
-function _capscorrect_civix_civicrm_xmlMenu(&$files) {
-  foreach (_capscorrect_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
-    $files[] = $file;
-  }
-}
-
-/**
- * Implementation of hook_civicrm_install
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
  */
 function _capscorrect_civix_civicrm_install() {
   _capscorrect_civix_civicrm_config();
   if ($upgrader = _capscorrect_civix_upgrader()) {
-    return $upgrader->onInstall();
+    $upgrader->onInstall();
+  }
+  _capscorrect_civix_mixin_polyfill();
+}
+
+/**
+ * Implements hook_civicrm_postInstall().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
+ */
+function _capscorrect_civix_civicrm_postInstall() {
+  _capscorrect_civix_civicrm_config();
+  if ($upgrader = _capscorrect_civix_upgrader()) {
+    if (is_callable([$upgrader, 'onPostInstall'])) {
+      $upgrader->onPostInstall();
+    }
   }
 }
 
 /**
- * Implementation of hook_civicrm_uninstall
+ * Implements hook_civicrm_uninstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
  */
 function _capscorrect_civix_civicrm_uninstall() {
   _capscorrect_civix_civicrm_config();
   if ($upgrader = _capscorrect_civix_upgrader()) {
-    return $upgrader->onUninstall();
+    $upgrader->onUninstall();
   }
 }
 
 /**
- * (Delegated) Implementation of hook_civicrm_enable
+ * (Delegated) Implements hook_civicrm_enable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
 function _capscorrect_civix_civicrm_enable() {
   _capscorrect_civix_civicrm_config();
   if ($upgrader = _capscorrect_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onEnable'))) {
-      return $upgrader->onEnable();
+    if (is_callable([$upgrader, 'onEnable'])) {
+      $upgrader->onEnable();
     }
   }
+  _capscorrect_civix_mixin_polyfill();
 }
 
 /**
- * (Delegated) Implementation of hook_civicrm_disable
+ * (Delegated) Implements hook_civicrm_disable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
+ * @return mixed
  */
 function _capscorrect_civix_civicrm_disable() {
   _capscorrect_civix_civicrm_config();
   if ($upgrader = _capscorrect_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onDisable'))) {
-      return $upgrader->onDisable();
+    if (is_callable([$upgrader, 'onDisable'])) {
+      $upgrader->onDisable();
     }
   }
 }
 
 /**
- * (Delegated) Implementation of hook_civicrm_upgrade
+ * (Delegated) Implements hook_civicrm_upgrade().
  *
  * @param $op string, the type of operation being performed; 'check' or 'enqueue'
  * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
  *
- * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *                for 'enqueue', returns void
+ * @return mixed
+ *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
+ *   for 'enqueue', returns void
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
 function _capscorrect_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
   if ($upgrader = _capscorrect_civix_upgrader()) {
@@ -112,149 +206,47 @@ function _capscorrect_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) 
  * @return CRM_Capscorrect_Upgrader
  */
 function _capscorrect_civix_upgrader() {
-  if (!file_exists(__DIR__.'/CRM/Capscorrect/Upgrader.php')) {
+  if (!file_exists(__DIR__ . '/CRM/Capscorrect/Upgrader.php')) {
     return NULL;
-  } else {
+  }
+  else {
     return CRM_Capscorrect_Upgrader_Base::instance();
   }
 }
 
 /**
- * Search directory tree for files which match a glob pattern
+ * Inserts a navigation menu item at a given place in the hierarchy.
  *
- * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
- * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
+ * @param array $menu - menu hierarchy
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
  *
- * @param $dir string, base dir
- * @param $pattern string, glob pattern, eg "*.txt"
- * @return array(string)
+ * @return bool
  */
-function _capscorrect_civix_find_files($dir, $pattern) {
-  if (is_callable(array('CRM_Utils_File', 'findFiles'))) {
-    return CRM_Utils_File::findFiles($dir, $pattern);
-  }
-
-  $todos = array($dir);
-  $result = array();
-  while (!empty($todos)) {
-    $subdir = array_shift($todos);
-    foreach (_capscorrect_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
-        $result[] = $match;
-      }
-    }
-    if ($dh = opendir($subdir)) {
-      while (FALSE !== ($entry = readdir($dh))) {
-        $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
-        } elseif (is_dir($path)) {
-          $todos[] = $path;
-        }
-      }
-      closedir($dh);
-    }
-  }
-  return $result;
-}
-/**
- * (Delegated) Implementation of hook_civicrm_managed
- *
- * Find any *.mgd.php files, merge their content, and return.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
- */
-function _capscorrect_civix_civicrm_managed(&$entities) {
-  $mgdFiles = _capscorrect_civix_find_files(__DIR__, '*.mgd.php');
-  foreach ($mgdFiles as $file) {
-    $es = include $file;
-    foreach ($es as $e) {
-      if (empty($e['module'])) {
-        $e['module'] = 'uk.org.futurefirst.networks.capscorrect';
-      }
-      $entities[] = $e;
-    }
-  }
-}
-
-/**
- * (Delegated) Implementation of hook_civicrm_caseTypes
- *
- * Find any and return any files matching "xml/case/*.xml"
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
- */
-function _capscorrect_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
-    return;
-  }
-
-  foreach (_capscorrect_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
-    $name = preg_replace('/\.xml$/', '', basename($file));
-    if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
-      $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      CRM_Core_Error::fatal($errorMessage);
-      // throw new CRM_Core_Exception($errorMessage);
-    }
-    $caseTypes[$name] = array(
-      'module' => 'uk.org.futurefirst.networks.capscorrect',
-      'name' => $name,
-      'file' => $file,
-    );
-  }
-}
-
-/**
- * Glob wrapper which is guaranteed to return an array.
- *
- * The documentation for glob() says, "On some systems it is impossible to
- * distinguish between empty match and an error." Anecdotally, the return
- * result for an empty match is sometimes array() and sometimes FALSE.
- * This wrapper provides consistency.
- *
- * @link http://php.net/glob
- * @param string $pattern
- * @return array, possibly empty
- */
-function _capscorrect_civix_glob($pattern) {
-  $result = glob($pattern);
-  return is_array($result) ? $result : array();
-}
-
-/**
- * Inserts a navigation menu item at a given place in the hierarchy
- *
- * $menu - menu hierarchy
- * $path - path where insertion should happen (ie. Administer/System Settings)
- * $item - menu you need to insert (parent/child attributes will be filled for you)
- * $parentId - used internally to recurse in the menu structure
- */
-function _capscorrect_civix_insert_navigation_menu(&$menu, $path, $item, $parentId = NULL) {
-  static $navId;
-
+function _capscorrect_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
   if (empty($path)) {
-    if (!$navId) $navId = CRM_Core_DAO::singleValueQuery("SELECT max(id) FROM civicrm_navigation");
-    $navId ++;
-    $menu[$navId] = array (
-      'attributes' => array_merge($item, array(
+    $menu[] = [
+      'attributes' => array_merge([
         'label'      => CRM_Utils_Array::value('name', $item),
         'active'     => 1,
-        'parentID'   => $parentId,
-        'navID'      => $navId,
-      ))
-    );
-    return true;
-  } else {
+      ], $item),
+    ];
+    return TRUE;
+  }
+  else {
     // Find an recurse into the next level down
-    $found = false;
+    $found = FALSE;
     $path = explode('/', $path);
     $first = array_shift($path);
     foreach ($menu as $key => &$entry) {
       if ($entry['attributes']['name'] == $first) {
-        if (!$entry['child']) $entry['child'] = array();
-        $found = _capscorrect_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item, $key);
+        if (!isset($entry['child'])) {
+          $entry['child'] = [];
+        }
+        $found = _capscorrect_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
       }
     }
     return $found;
@@ -262,17 +254,55 @@ function _capscorrect_civix_insert_navigation_menu(&$menu, $path, $item, $parent
 }
 
 /**
- * (Delegated) Implementation of hook_civicrm_alterSettingsFolders
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
+ * (Delegated) Implements hook_civicrm_navigationMenu().
  */
-function _capscorrect_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  static $configured = FALSE;
-  if ($configured) return;
-  $configured = TRUE;
-
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if(is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
-    $metaDataFolders[] = $settingsDir;
+function _capscorrect_civix_navigationMenu(&$nodes) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
+    _capscorrect_civix_fixNavigationMenu($nodes);
   }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _capscorrect_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+  });
+  _capscorrect_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _capscorrect_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _capscorrect_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_entityTypes().
+ *
+ * Find any *.entityType.php files, merge their content, and return.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
+ */
+function _capscorrect_civix_civicrm_entityTypes(&$entityTypes) {
+  $entityTypes = array_merge($entityTypes, []);
 }

--- a/capscorrect.php
+++ b/capscorrect.php
@@ -21,17 +21,6 @@ function capscorrect_civicrm_config(&$config) {
 }
 
 /**
- * Implementation of hook_civicrm_xmlMenu
- *
- * @param $files array(string)
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
- */
-function capscorrect_civicrm_xmlMenu(&$files) {
-  _capscorrect_civix_civicrm_xmlMenu($files);
-}
-
-/**
  * Implementation of hook_civicrm_install
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
@@ -88,36 +77,20 @@ function capscorrect_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
   return _capscorrect_civix_civicrm_upgrade($op, $queue);
 }
 
-/**
- * Implementation of hook_civicrm_managed
- *
- * Generate a list of entities to create/deactivate/delete when this module
- * is installed, disabled, uninstalled.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
- */
-function capscorrect_civicrm_managed(&$entities) {
-  return _capscorrect_civix_civicrm_managed($entities);
-}
+// /**
+//  * Implements hook_civicrm_postInstall().
+//  *
+//  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
+//  */
+// function capscorrect_civicrm_postInstall() {
+//   _capscorrect_civix_civicrm_postInstall();
+// }
 
-/**
- * Implementation of hook_civicrm_caseTypes
- *
- * Generate a list of case-types
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
- */
-function capscorrect_civicrm_caseTypes(&$caseTypes) {
-  _capscorrect_civix_civicrm_caseTypes($caseTypes);
-}
-
-/**
- * Implementation of hook_civicrm_alterSettingsFolders
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
- */
-function capscorrect_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _capscorrect_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
+// /**
+//  * Implements hook_civicrm_entityTypes().
+//  *
+//  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
+//  */
+// function capscorrect_civicrm_entityTypes(&$entityTypes) {
+//   _capscorrect_civix_civicrm_entityTypes($entityTypes);
+// }

--- a/info.xml
+++ b/info.xml
@@ -24,5 +24,9 @@
   <comments>The number of contacts scanned each day can be set in Civi's scheduled job settings page.</comments>
   <civix>
     <namespace>CRM/Capscorrect</namespace>
+    <format>22.05.2</format>
   </civix>
+  <mixins>
+    <mixin>mgd-php@1.0.0</mixin>
+  </mixins>
 </extension>

--- a/mixin/mgd-php@1.0.0.mixin.php
+++ b/mixin/mgd-php@1.0.0.mixin.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Auto-register "**.mgd.php" files.
+ *
+ * @mixinName mgd-php
+ * @mixinVersion 1.0.0
+ *
+ * @param CRM_Extension_MixInfo $mixInfo
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ * @param \CRM_Extension_BootCache $bootCache
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ */
+return function ($mixInfo, $bootCache) {
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @see CRM_Utils_Hook::managed()
+   */
+  Civi::dispatcher()->addListener('hook_civicrm_managed', function ($event) use ($mixInfo) {
+    // When deactivating on a polyfill/pre-mixin system, listeners may not cleanup automatically.
+    if (!$mixInfo->isActive()) {
+      return;
+    }
+
+    $mgdFiles = CRM_Utils_File::findFiles($mixInfo->getPath(), '*.mgd.php');
+    sort($mgdFiles);
+    foreach ($mgdFiles as $file) {
+      $es = include $file;
+      foreach ($es as $e) {
+        if (empty($e['module'])) {
+          $e['module'] = $mixInfo->longName;
+        }
+        if (empty($e['params']['version'])) {
+          $e['params']['version'] = '3';
+        }
+        $event->entities[] = $e;
+      }
+    }
+  });
+
+};

--- a/mixin/polyfill.php
+++ b/mixin/polyfill.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * When deploying on systems that lack mixin support, fake it.
+ *
+ * @mixinFile polyfill.php
+ *
+ * This polyfill does some (persnickity) deduplication, but it doesn't allow upgrades or shipping replacements in core.
+ *
+ * Note: The polyfill.php is designed to be copied into extensions for interoperability. Consequently, this file is
+ * not used 'live' by `civicrm-core`. However, the file does need a canonical home, and it's convenient to keep it
+ * adjacent to the actual mixin files.
+ *
+ * @param string $longName
+ * @param string $shortName
+ * @param string $basePath
+ */
+return function ($longName, $shortName, $basePath) {
+  // Construct imitations of the mixin services. These cannot work as well (e.g. with respect to
+  // number of file-reads, deduping, upgrading)... but they should be OK for a few months while
+  // the mixin services become available.
+
+  // List of active mixins; deduped by version
+  $mixinVers = [];
+  foreach ((array) glob($basePath . '/mixin/*.mixin.php') as $f) {
+    [$name, $ver] = explode('@', substr(basename($f), 0, -10));
+    if (!isset($mixinVers[$name]) || version_compare($ver, $mixinVers[$name], '>')) {
+      $mixinVers[$name] = $ver;
+    }
+  }
+  $mixins = [];
+  foreach ($mixinVers as $name => $ver) {
+    $mixins[] = "$name@$ver";
+  }
+
+  // Imitate CRM_Extension_MixInfo.
+  $mixInfo = new class() {
+
+    /**
+     * @var string
+     */
+    public $longName;
+
+    /**
+     * @var string
+     */
+    public $shortName;
+
+    public $_basePath;
+
+    public function getPath($file = NULL) {
+      return $this->_basePath . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+    }
+
+    public function isActive() {
+      return \CRM_Extension_System::singleton()->getMapper()->isActiveModule($this->shortName);
+    }
+
+  };
+  $mixInfo->longName = $longName;
+  $mixInfo->shortName = $shortName;
+  $mixInfo->_basePath = $basePath;
+
+  // Imitate CRM_Extension_BootCache.
+  $bootCache = new class() {
+
+    public function define($name, $callback) {
+      $envId = \CRM_Core_Config_Runtime::getId();
+      $oldExtCachePath = \Civi::paths()->getPath("[civicrm.compile]/CachedExtLoader.{$envId}.php");
+      $stat = stat($oldExtCachePath);
+      $file = Civi::paths()->getPath('[civicrm.compile]/CachedMixin.' . md5($name . ($stat['mtime'] ?? 0)) . '.php');
+      if (file_exists($file)) {
+        return include $file;
+      }
+      else {
+        $data = $callback();
+        file_put_contents($file, '<' . "?php\nreturn " . var_export($data, 1) . ';');
+        return $data;
+      }
+    }
+
+  };
+
+  // Imitate CRM_Extension_MixinLoader::run()
+  // Parse all live mixins before trying to scan any classes.
+  global $_CIVIX_MIXIN_POLYFILL;
+  foreach ($mixins as $mixin) {
+    // If the exact same mixin is defined by multiple exts, just use the first one.
+    if (!isset($_CIVIX_MIXIN_POLYFILL[$mixin])) {
+      $_CIVIX_MIXIN_POLYFILL[$mixin] = include_once $basePath . '/mixin/' . $mixin . '.mixin.php';
+    }
+  }
+  foreach ($mixins as $mixin) {
+    // If there's trickery about installs/uninstalls/resets, then we may need to register a second time.
+    if (!isset(\Civi::$statics[__FUNCTION__][$mixin])) {
+      \Civi::$statics[__FUNCTION__][$mixin] = 1;
+      $func = $_CIVIX_MIXIN_POLYFILL[$mixin];
+      $func($mixInfo, $bootCache);
+    }
+  }
+};


### PR DESCRIPTION
PR to address PHP warnings on newer versions (7.x) about offset access syntax by running `civix upgrade`:

PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in wp-content/uploads/civicrm/extensions/capscorrect-1.1/capscorrect.civix.php on line 149